### PR TITLE
Fix Windows support by replacing backslashes in cwd path

### DIFF
--- a/lua/agitator/time_machine.lua
+++ b/lua/agitator/time_machine.lua
@@ -45,7 +45,7 @@ local function git_time_machine_display()
     vim.bo.modifiable = true
     vim.api.nvim_command('%delete')
     local complete_fname = utils.git_root_folder() .. '/' .. vim.b.time_machine_entries[i].filename
-    local relative_fname = complete_fname:gsub(escape_pattern(vim.fn.getcwd()) .. '/', '')
+    local relative_fname = complete_fname:gsub(utils.escape_pattern(utils.get_cwd()) .. '/', '')
     utils.open_file_branch(commit_sha, relative_fname)
     if vim.b.time_machine_init_line_no ~= nil then
         -- one-time only: restore the line number from the original buffer

--- a/lua/agitator/utils.lua
+++ b/lua/agitator/utils.lua
@@ -1,3 +1,11 @@
+local function get_cwd()
+    local cwd = vim.fn.getcwd()
+    if vim.fn.has("win32") then
+        return cwd:gsub("\\", "/")
+    else
+        return cwd
+    end
+end
 -- https://vi.stackexchange.com/a/3749/38754
 local function open_file_branch(branch, fname)
     vim.api.nvim_exec('silent r! git show ' .. branch .. ':./' .. fname, false)
@@ -6,7 +14,7 @@ local function open_file_branch(branch, fname)
     local base_bufcmd = 'silent file [' .. branch .. '] ' .. fname_without_path
     local git_root_folder = git_root_folder()
     local commit = commit_head_of_branch(branch)
-    local path_in_git_prj = (vim.fn.getcwd() .. '/' .. fname):gsub(escape_pattern(git_root_folder) .. '/', '')
+    local path_in_git_prj = (get_cwd() .. '/' .. fname):gsub(escape_pattern(git_root_folder) .. '/', '')
     vim.b.agitator_commit = commit
     vim.b.agitator_path_in_git_prj = path_in_git_prj
     -- if we try to open twice the same file from the same branch, we get
@@ -111,7 +119,7 @@ local function get_relative_fname()
       or vim.api.nvim_buf_call(0, function()
         return vim.fn.expand('%:p')
     end)
-    return fname:gsub(escape_pattern(vim.fn.getcwd()) .. '/', '')
+    return fname:gsub(escape_pattern(get_cwd()) .. '/', '')
 end
 
 return {
@@ -120,4 +128,5 @@ return {
     escape_pattern = escape_pattern,
     git_root_folder = git_root_folder,
     fname_commit_associated_with_buffer = fname_commit_associated_with_buffer,
+    get_cwd = get_cwd,
 }


### PR DESCRIPTION
Thanks for the great plugin!

On Windows, `vim.fn.getcwd()` returns a path that is backslash-separated. However, Git for Windows uses forward slashes for file separators. This breaks the ability to get a file path relative to the git root, which subsequently breaks a lot of operations.

The least invasive fix I could think of was to transform any backslashes in `getcwd()` to forward slashes and ensure that this is only done on Windows systems. I figured that a new `utils.get_cwd()` function would be a good way to keep the platform check clean and isolated.

Hope that makes sense. I'm open to any feedback you might have.