### PR TITLE
new feature: option in time machine to open on a specific sha 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ It opens a new read-only window, where you can navigate through
 past versions of the file and view their contents.
 Details about the currently displayed version appear in a popup window at the bottom-right.
 
-- `git_time_machine({use_current_win?, set_custom_shortcuts?, popup_last_line?, popup_width?})`
+- `git_time_machine({use_current_win?, commit_sha?, set_custom_shortcuts?, popup_last_line?, popup_width?})`
 
 You can pass in `{use_current_win: true}` to reuse the current window instead of creating a new one.
+
+You can also pass in `{commit_sha: "your-sha"}` to open the time machine focused on a specific commit.
+The sha can be a full or short sha (without the `#` prefix).
 
 `set_custom_shortcuts` allows to customize the shortcuts for the time machine.
 It should be a function, that'll receive the buffer number of the time machine.

--- a/lua/agitator/time_machine.lua
+++ b/lua/agitator/time_machine.lua
@@ -66,6 +66,18 @@ local function git_time_machine_next()
     git_time_machine_display()
 end
 
+local function git_time_machine_focus(sha)
+    for index, entry in ipairs(vim.b.time_machine_entries) do
+        if string.sub(entry.sha, 1, string.len(sha)) == sha then
+            vim.b.time_machine_cur_idx = index
+            git_time_machine_display()
+            return true
+        end
+    end
+    vim.cmd([[echohl ErrorMsg | echo "Given commit sha doesn't exist in this file's history" | echohl None]])
+    return false
+end
+
 local function git_time_machine_previous()
     if vim.b.time_machine_cur_idx < #vim.b.time_machine_entries then
         vim.b.time_machine_cur_idx = vim.b.time_machine_cur_idx + 1
@@ -139,9 +151,15 @@ local function handle_time_machine(lines, opts)
     vim.b.time_machine_entries = parse_time_machine(lines)
     vim.b.time_machine_cur_idx = 1
     if #vim.b.time_machine_entries >= 1 then
+        if opts ~= nil and opts.commit_sha then
+            if git_time_machine_focus(opts.commit_sha) then
+                return
+            end
+        end
+        -- Fallback to next
         git_time_machine_next()
     else
-        vim.cmd[[echohl ErrorMsg | echo "No git history for file!" | echohl None]]
+        vim.cmd([[echohl ErrorMsg | echo "No git history for file!" | echohl None]])
         git_time_machine_quit(opts)
     end
 end

--- a/lua/agitator/time_machine.lua
+++ b/lua/agitator/time_machine.lua
@@ -68,7 +68,8 @@ end
 
 local function git_time_machine_focus(sha)
     for index, entry in ipairs(vim.b.time_machine_entries) do
-        if string.sub(entry.sha, 1, string.len(sha)) == sha then
+        -- The param sha could be a short sha, so check against the start of the time machine full sha
+        if string.sub(entry.sha, 1, #sha) == sha then
             vim.b.time_machine_cur_idx = index
             git_time_machine_display()
             return true
@@ -151,6 +152,7 @@ local function handle_time_machine(lines, opts)
     vim.b.time_machine_entries = parse_time_machine(lines)
     vim.b.time_machine_cur_idx = 1
     if #vim.b.time_machine_entries >= 1 then
+        -- Focus the given commit sha if possible
         if opts ~= nil and opts.commit_sha then
             if git_time_machine_focus(opts.commit_sha) then
                 return


### PR DESCRIPTION
The PR adds the "commit_sha" option to the time machine open function.
If the given sha is found in the file's history, the time machine will be opened on the sha directly.
If it is not found, a message is shown and the time machine opens as it would normally.

I've added this functionality to use in conjunction with some picker, in my case with a Snacks picker.